### PR TITLE
fixed syntax error for non-unix warning

### DIFF
--- a/cli/src/util.rs
+++ b/cli/src/util.rs
@@ -22,7 +22,7 @@ pub fn create_private_file(path: &Path) -> Result<File> {
     // TODO: Figure out how file permissions work on Windows, or link to an issue
     #[cfg(not(unix))]
     eprintln!(
-        "Warning! You should set the permissions for {} to only be readable by this user!"
+        "Warning! You should set the permissions for {} to only be readable by this user!",
         PATHS.user_info.display()
     );
 


### PR DESCRIPTION
this fixes https://github.com/jamesmunns/frauth/issues/9 when using msvc
compiler instead of gnu