### PR TITLE
Add 'frauth me' and status get/set

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -52,6 +52,9 @@ enum SubCommands {
     /// Initialize frauth, creating keys and necessary directories
     Init,
 
+    /// Modify your own config
+    Me,
+
     /// Render a file that can be placed on a static website
     Publish(PublishOpts),
 
@@ -64,6 +67,7 @@ fn main() -> Result<()> {
 
     let ret = match opt {
         SubCommands::Init => subcmd::init::init(),
+        SubCommands::Me => subcmd::me::me(),
         SubCommands::Publish(opts) => subcmd::publish::publish(&opts),
         SubCommands::Friend(opts) => subcmd::friend::friend(&opts),
     };

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -4,7 +4,7 @@ use directories::ProjectDirs;
 use lazy_static::lazy_static;
 use structopt::StructOpt;
 
-use crate::subcmd::{friend::FriendOpts, publish::PublishOpts};
+use crate::subcmd::{friend::FriendOpts, me::MeOpts, publish::PublishOpts};
 
 pub mod consts;
 pub mod schema;
@@ -53,7 +53,7 @@ enum SubCommands {
     Init,
 
     /// Modify your own config
-    Me,
+    Me(MeOpts),
 
     /// Render a file that can be placed on a static website
     Publish(PublishOpts),
@@ -67,7 +67,7 @@ fn main() -> Result<()> {
 
     let ret = match opt {
         SubCommands::Init => subcmd::init::init(),
-        SubCommands::Me => subcmd::me::me(),
+        SubCommands::Me(opts) => subcmd::me::me(&opts),
         SubCommands::Publish(opts) => subcmd::publish::publish(&opts),
         SubCommands::Friend(opts) => subcmd::friend::friend(&opts),
     };

--- a/cli/src/subcmd/init.rs
+++ b/cli/src/subcmd/init.rs
@@ -6,9 +6,9 @@ use rand::rngs::OsRng;
 use toml::to_string;
 
 use crate::{
-    consts::{FRIEND_INFO_HEADER, PEER_INFO_HEADER, USER_INFO_HEADER},
+    consts::{FRIEND_INFO_HEADER, PEER_INFO_HEADER},
     schema::{Friends, Peers, UserInfo},
-    util::create_private_file,
+    util::{create_private_file, write_user_info},
     Error, Result, PATHS,
 };
 
@@ -43,7 +43,7 @@ pub fn init() -> Result<()> {
     create_dir_all(&PATHS.base_cache)?;
 
     // Create files early to prevent late errors
-    let mut user_info_file = create_private_file(&PATHS.user_info)?;
+    let _ = create_private_file(&PATHS.user_info)?;
     let mut friend_info_file = create_private_file(&PATHS.friend_info)?;
     let mut peer_info_file = create_private_file(&PATHS.peer_info)?;
 
@@ -105,12 +105,10 @@ pub fn init() -> Result<()> {
         keypair,
     };
 
-    let contents = to_string(&user_info)?;
     let empty_friends = to_string(&Friends::default())?;
     let empty_peers = to_string(&Peers::default())?;
 
-    user_info_file.write_all(USER_INFO_HEADER.as_bytes())?;
-    user_info_file.write_all(contents.as_bytes())?;
+    write_user_info(&user_info)?;
 
     friend_info_file.write_all(FRIEND_INFO_HEADER.as_bytes())?;
     friend_info_file.write_all(empty_friends.as_bytes())?;

--- a/cli/src/subcmd/me.rs
+++ b/cli/src/subcmd/me.rs
@@ -1,5 +1,51 @@
 use crate::Result;
 
-pub fn me() -> Result<()> {
+use structopt::StructOpt;
+
+use crate::util::{load_user_info, write_user_info};
+
+#[derive(StructOpt, Debug)]
+#[structopt(rename_all = "kebab-case")]
+pub enum MeOpts {
+    /// Modify your status
+    Status(StatusOpts),
+}
+
+#[derive(StructOpt, Debug)]
+#[structopt(rename_all = "kebab-case")]
+pub enum StatusOpts {
+    /// Get your current status
+    Get,
+
+    /// Set a new status
+    Set{
+        /// The new status
+        status: String
+    },
+}
+
+pub fn me(subcmd: &MeOpts) -> Result<()> {
+    match subcmd {
+        MeOpts::Status(opts) => status(opts),
+    }
+}
+
+fn status(opts: &StatusOpts) -> Result<()> {
+    let mut user_info = load_user_info()?;
+
+    match opts {
+        StatusOpts::Get => {
+            match user_info.status {
+                Some(status) => println!("{}", status),
+                None => println!("You haven't set a status yet!"),
+            }
+        },
+        StatusOpts::Set { status } => {
+            user_info.status = Some(status.clone());
+
+            write_user_info(&user_info)?;
+        },
+    }
+
     Ok(())
 }

--- a/cli/src/subcmd/me.rs
+++ b/cli/src/subcmd/me.rs
@@ -1,0 +1,5 @@
+use crate::Result;
+
+pub fn me() -> Result<()> {
+    Ok(())
+}

--- a/cli/src/subcmd/me.rs
+++ b/cli/src/subcmd/me.rs
@@ -22,6 +22,9 @@ pub enum StatusOpts {
         /// The new status
         status: String
     },
+
+    /// Clear your status
+    Clear,
 }
 
 pub fn me(subcmd: &MeOpts) -> Result<()> {
@@ -37,14 +40,17 @@ fn status(opts: &StatusOpts) -> Result<()> {
         StatusOpts::Get => {
             match user_info.status {
                 Some(status) => println!("{}", status),
-                None => println!("You haven't set a status yet!"),
+                None => println!("You haven't set a status!"),
             }
         },
         StatusOpts::Set { status } => {
             user_info.status = Some(status.clone());
-
             write_user_info(&user_info)?;
         },
+        StatusOpts::Clear => {
+            user_info.status = None;
+            write_user_info(&user_info)?;
+        }
     }
 
     Ok(())

--- a/cli/src/subcmd/mod.rs
+++ b/cli/src/subcmd/mod.rs
@@ -1,3 +1,4 @@
 pub mod friend;
 pub mod init;
+pub mod me;
 pub mod publish;

--- a/cli/src/subcmd/publish.rs
+++ b/cli/src/subcmd/publish.rs
@@ -1,5 +1,5 @@
 use std::{
-    fs::{read_to_string, OpenOptions},
+    fs::OpenOptions,
     io::Write,
     path::PathBuf,
 };
@@ -7,12 +7,12 @@ use std::{
 use base64::encode;
 use chrono::Utc;
 use structopt::StructOpt;
-use toml::{from_str, to_string};
+use toml::to_string;
 
 use crate::{
     schema::{PublishFriend, PublishUserInfo, UserInfo},
-    util::load_friends,
-    Result, PATHS,
+    util::{load_user_info, load_friends},
+    Result,
 };
 
 pub const HEADER_TOP: &str = "FRAUTH-CONTENTS\n";
@@ -28,7 +28,7 @@ pub struct PublishOpts {
 }
 
 pub fn publish(opts: &PublishOpts) -> Result<()> {
-    let user_info = load_user_file()?;
+    let user_info = load_user_info()?;
     let contents = render_to_string(user_info)?;
 
     if let Some(ref path) = opts.output {
@@ -44,16 +44,6 @@ pub fn publish(opts: &PublishOpts) -> Result<()> {
     }
 
     Ok(())
-}
-
-fn load_user_file() -> Result<UserInfo> {
-    let contents = read_to_string(&PATHS.user_info)?;
-    from_str(&contents)
-        .map_err(|e| {
-            println!("{:?}", e);
-            e
-        })
-        .map_err(|_| "Failed to parse user info!".into())
 }
 
 fn render_to_string(mut user_info: UserInfo) -> Result<String> {

--- a/cli/src/util.rs
+++ b/cli/src/util.rs
@@ -1,11 +1,16 @@
 use std::{
     fs::{read_to_string, File, OpenOptions},
+    io::Write,
     path::Path,
 };
 
-use toml::from_str;
+use toml::{from_str, to_string};
 
-use crate::{schema::Friends, Error, Result, PATHS};
+use crate::{
+    consts::USER_INFO_HEADER,
+    schema::{Friends, UserInfo},
+    {Error, Result, PATHS},
+};
 
 #[cfg(unix)]
 use std::os::unix::fs::OpenOptionsExt;
@@ -29,6 +34,37 @@ pub fn create_private_file(path: &Path) -> Result<File> {
     opt.open(path).map_err(|e| {
         Error::from(format!("Failed to open file: {}\nReason: {}", path.display(), e).as_str())
     })
+}
+
+fn open_existing_file(path: &Path) -> Result<File> {
+    let mut opt = OpenOptions::new();
+    opt.write(true);
+
+    opt.open(path).map_err(|e| {
+        Error::from(format!("Failed to open file: {}\nReason: {}", path.display(), e).as_str())
+    })
+}
+
+pub fn load_user_info() -> Result<UserInfo> {
+    let contents = read_to_string(&PATHS.user_info)?;
+
+    from_str(&contents)
+        .map_err(|e| {
+            println!("{:?}", e);
+            e
+        })
+        .map_err(|_| "Failed to parse user info!".into())
+}
+
+pub fn write_user_info(user_info: &UserInfo) -> Result<()> {
+    let mut user_info_file = open_existing_file(&PATHS.user_info)?;
+    let contents = to_string(&user_info)?;
+
+    user_info_file.set_len(0)?;
+    user_info_file.write_all(USER_INFO_HEADER.as_bytes())?;
+    user_info_file.write_all(contents.as_bytes())?;
+
+    Ok(())
 }
 
 pub fn load_friends() -> Result<Friends> {


### PR DESCRIPTION
First PR for #18.

This adds the `frauth me` command.

I have added a first subcommand `frauth me status`.
You can do:
- `frauth me status get`: this returns the current status or if it's empty a notice
- `frauth me status set <string>`: configures a new status
- `frauth me status clear`: remove the set status

I plan on adding other subcommands, but I wanted to share this first to vet the general design.

---

To get/set the status I had to load and write `UserInfo` (aka the file `me.frauth`). Because I wanted to avoid duplicating code I have been moving some stuff around:
- since `init` already writes the user info, I moved this function to util
- since `publish` already loads the user info, I moved this function to util as well
- util ends up with 2 new helper functions: `load_user_info` & `write_user_info`

In retrospect, it was probably better to just duplicate some code and refactor it away later...