### PR TITLE
Add 'frauth me view/edit'

### DIFF
--- a/cli/src/subcmd/me.rs
+++ b/cli/src/subcmd/me.rs
@@ -162,7 +162,7 @@ fn edit(opts: &EditOpts) -> Result<()> {
         },
     }
     write_user_info(&user_info)?;
-    println!("Updated configuration, don't forget to (re)publish me.frauth!");
+    println!("Updated configuration, don't forget to (re)publish with `frauth publish`!");
 
     Ok(())
 }

--- a/cli/src/subcmd/me.rs
+++ b/cli/src/subcmd/me.rs
@@ -1,57 +1,168 @@
 use crate::Result;
 
+use base64::encode;
 use structopt::StructOpt;
 
-use crate::util::{load_user_info, write_user_info};
+use crate::{
+    util::{load_user_info, write_user_info},
+    Error,
+};
 
 #[derive(StructOpt, Debug)]
 #[structopt(rename_all = "kebab-case")]
 pub enum MeOpts {
-    /// Modify your status
-    Status(StatusOpts),
+    /// View your configuration
+    View {
+        #[structopt(subcommand)]
+        cmd: Option<ViewCmd>,
+    },
+    /// Edit your configuration
+    Edit(EditOpts),
 }
 
 #[derive(StructOpt, Debug)]
 #[structopt(rename_all = "kebab-case")]
-pub enum StatusOpts {
-    /// Get your current status
-    Get,
+pub enum ViewCmd {
+    /// Print your name
+    Name,
+    /// Print your current status, if any is set
+    Status,
+    /// Print your public key
+    Pubkey,
+    /// Print all identities
+    Identities,
+}
 
-    /// Set a new status
-    Set{
-        /// The new status
-        status: String
+#[derive(StructOpt, Debug)]
+#[structopt(rename_all = "kebab-case")]
+pub enum EditOpts {
+    /// Edit your display name
+    Name {
+        /// The display name to set
+        name: String,
     },
+    /// Edit your status
+    Status(StatusOpts),
+    /// Manage your identities
+    Identities(IdentitiesOpts),
+}
 
-    /// Clear your status
-    Clear,
+#[derive(StructOpt, Debug)]
+#[structopt(rename_all = "kebab-case")]
+pub struct StatusOpts {
+    /// The status to set
+    #[structopt(required_unless = "clear")]
+    status: Option<String>,
+    /// Clear the status
+    #[structopt(long)]
+    clear: bool,
+}
+
+#[derive(StructOpt, Debug)]
+#[structopt(rename_all = "kebab-case")]
+pub enum IdentitiesOpts {
+    /// Add a new identity
+    Add {
+        /// The name of the identity (i.e. 'twitter', 'email' etc.)
+        name: String,
+        /// The id of the identity (i.e. 'my_twitter_id', 'me@example.com', etc.)
+        id: String,
+    },
+    /// Modify an existing identity
+    Modify {
+        /// The name of the identity
+        name: String,
+        /// The id of the identity
+        id: String,
+    },
+    /// Remove an identity
+    Remove {
+        /// The name of the identity
+        name: String,
+    },
 }
 
 pub fn me(subcmd: &MeOpts) -> Result<()> {
     match subcmd {
-        MeOpts::Status(opts) => status(opts),
+        MeOpts::View { cmd } => match cmd {
+            Some(cmd) => view(cmd),
+            None => view_all(),
+        },
+        MeOpts::Edit(opts) => edit(opts),
     }
 }
 
-fn status(opts: &StatusOpts) -> Result<()> {
+fn view_all() -> Result<()> {
+    let user_info = load_user_info()?;
+
+    println!("Name:       {}", user_info.name);
+    println!("Status:     {}", user_info.status.unwrap_or_else(|| "<no status is set>".to_string()));
+    println!("Public key: {}", encode(user_info.keypair.public.as_bytes()));
+
+    println!("\nIdentities:");
+    for (name, id) in user_info.identities.iter() {
+        println!("  - {}: {}", name, id);
+    }
+
+    Ok(())
+}
+
+fn view(cmd: &ViewCmd) -> Result<()> {
+    let user_info = load_user_info()?;
+
+    match cmd {
+        ViewCmd::Name => {
+            println!("{}", user_info.name);
+        }
+        ViewCmd::Status => match user_info.status {
+            Some(status) => println!("{}", status),
+            None => println!("You haven't set a status!"),
+        },
+        ViewCmd::Pubkey => {
+            println!("{}", encode(user_info.keypair.public.as_bytes()));
+        }
+        ViewCmd::Identities => {
+            for (name, id) in user_info.identities.iter() {
+                println!("{}: {}", name, id);
+            }
+        }
+    }
+    Ok(())
+}
+
+fn edit(opts: &EditOpts) -> Result<()> {
     let mut user_info = load_user_info()?;
 
     match opts {
-        StatusOpts::Get => {
-            match user_info.status {
-                Some(status) => println!("{}", status),
-                None => println!("You haven't set a status!"),
+        EditOpts::Name { name } => {
+            user_info.name = name.clone();
+        }
+        EditOpts::Status(opts) => {
+            user_info.status = opts.status.clone();
+        }
+        EditOpts::Identities(opts) => match opts {
+            IdentitiesOpts::Add { id, name } => {
+                if user_info.identities.contains_key(name) {
+                    return Err(Error::from(format!("identity '{}' already exists, use modify instead", name)));
+                }
+                user_info.identities.insert(name.clone(), id.clone());
+            }
+            IdentitiesOpts::Modify { id, name } => {
+                if !user_info.identities.contains_key(name) {
+                    return Err(Error::from(format!("identity '{}' does not exist, use add instead", name)));
+                }
+                user_info.identities.insert(name.clone(), id.clone());
+            }
+            IdentitiesOpts::Remove { name } => {
+                match user_info.identities.remove(name) {
+                    Some(_) => {},
+                    None => return Err(Error::from(format!("can't remove identity '{}', identity does not exist!", name))),
+                };
             }
         },
-        StatusOpts::Set { status } => {
-            user_info.status = Some(status.clone());
-            write_user_info(&user_info)?;
-        },
-        StatusOpts::Clear => {
-            user_info.status = None;
-            write_user_info(&user_info)?;
-        }
     }
+    write_user_info(&user_info)?;
+    println!("Updated configuration, don't forget to (re)publish me.frauth!");
 
     Ok(())
 }


### PR DESCRIPTION
Closes #18 
Closes #24

This PR adds the commands:

- `frauth me view`
  - top-level command prints a summary
  - you can specify a specific field to print (`name`, `status`, `pubkey` or `identities`)
- `frauth me edit`
  - you can set a new `name` or `status`, i.e. `frauth me edit status 'Hello world'`
  - you can `add`, `modify`, `remove` identities, i.e.: `frauth me edit identities add 'twitter' 'koenaad'`

This implementation diverges a bit from my previous PR (#20). I first continued down that route, but found the get/set commands to feel uncomfortable. This PR is closer to what @jamesmunns  described in #18. I've found `frauth me view ...` and `frauth me edit ...` to be simpler and less typing.
You can still find that implementation here: https://github.com/koenaad/frauth/blob/more_me/cli/src/subcmd/me.rs
The flow there would have been: `frauth me status get` and `frauth me status set 'foo'`.

Some considerations that popped up:
- Do we want to allow people to change their name? And how should this update be propagated to other users i.e. in `frauth friend list`?
- I have made all commands non-interactive, mostly to keep it simple. Because of this the flow feels different from `frauth init`. I don't think this is really a problem since the use case of `frauth init` and `frauth me` differ quite a bit.
  (we could add this later as `frauth me edit --interactive` https://github.com/jamesmunns/frauth/issues/18#issuecomment-575906578)
- I noticed structopt/clap already defaults to kebab-case, so I think we can remove the `#[structopt(rename_all = "kebab-case")]`.